### PR TITLE
Chore: metabase ingress knp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ install: CHART_DIR=./cas-obps-postgres
 install: CHART_INSTANCE=cas-obps-postgres
 install: HELM_OPTS=--atomic --wait-for-jobs --timeout 2400s --namespace $(NAMESPACE) \
 										--set defaultImageTag=$(IMAGE_TAG) \
+										--set metabase.prefix=$(GGIRCS_NAMESPACE_PREFIX) \
+										--set metabase.environment=$(ENVIRONMENT) \
 										--values $(CHART_DIR)/values-$(ENVIRONMENT).yaml
 install:
 	@set -euo pipefail; \

--- a/cas-obps-postgres/templates/allowMetabaseAccess.yaml
+++ b/cas-obps-postgres/templates/allowMetabaseAccess.yaml
@@ -1,0 +1,19 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: obps-metabase-access
+  labels: {{ include "cas-obps-postgres.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      postgres-operator.crunchydata.com/role: replica
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: cas-metabase
+          namespaceSelector:
+            matchLabels:
+              environment: {{ .Values.metabase.environment }}
+              name: {{ .Values.metabase.prefix }}

--- a/cas-obps-postgres/values.yaml
+++ b/cas-obps-postgres/values.yaml
@@ -87,3 +87,7 @@ terraform-bucket-provision:
   terraform:
     namespace_apps: '["obps-backups"]'
     workspace: postgres
+
+metabase:
+  prefix: ~
+  environment: ~


### PR DESCRIPTION
Add a kubernetes network policy to allow metabase to read the read-only replicas of the cas-obps-postgres database