### PR TITLE
chore: post-migration to pg16

### DIFF
--- a/cas-obps-postgres/templates/PostgresCluster.yaml
+++ b/cas-obps-postgres/templates/PostgresCluster.yaml
@@ -21,7 +21,7 @@ spec:
   #           memory: 64Mi
   metadata:
     labels: {{ include "cas-obps-postgres.labels" . | nindent 6 }}
-  postgresVersion: 14
+  postgresVersion: 16
   instances:
     - name: pgha1
       replicas: {{ .Values.replicaCount }}


### PR DESCRIPTION
Effectively freezing the postgres version in the chart