### PR TITLE
chore: update knp to include port for pgbackrest jobs

### DIFF
--- a/cas-obps-postgres/templates/NetworkPolicy.yaml
+++ b/cas-obps-postgres/templates/NetworkPolicy.yaml
@@ -20,3 +20,5 @@ spec:
           port: 8008
         - protocol: TCP
           port: 2022
+        - protocol: TCP
+          port: 8432


### PR DESCRIPTION
needed the 8432 port added to ingress to allow pgbackrest jobs to reach the db