### PR TITLE
chore: tune postgres pods

### DIFF
--- a/cas-obps-postgres/values-prod.yaml
+++ b/cas-obps-postgres/values-prod.yaml
@@ -1,13 +1,12 @@
-replicaCount: 3
+replicaCount: 2
 
 environment: prod
 
 resources:
   requests:
-    cpu: 150m
-    memory: 150Mi
-  limits:
-    cpu: 600m
+    cpu: 250m
     memory: 600Mi
+  limits:
+    memory: 1200Mi
 
 storageSize: 3Gi


### PR DESCRIPTION
Part of [#2980](https://github.com/orgs/bcgov/projects/123/views/19?pane=issue&itemId=101178888&issue=bcgov%7Ccas-registration%7C2980). Tunes the Postgres pods for BCIERS.

## Changes 🚧

- Dropped CPU limits
- Tuned CPU request and Memory request/limit