### PR TITLE
Chore/2540 pgo separate wal pvc

### DIFF
--- a/cas-obps-postgres/Chart.yaml
+++ b/cas-obps-postgres/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/cas-obps-postgres/templates/PostgresCluster.yaml
+++ b/cas-obps-postgres/templates/PostgresCluster.yaml
@@ -56,12 +56,14 @@ spec:
                 matchLabels:
                   postgres-operator.crunchydata.com/cluster: {{ template "cas-obps-postgres.fullname" . }}
                   postgres-operator.crunchydata.com/instance-set: pgha1
+      {{- if .Values.wal.separateStorage }}
       walVolumeClaimSpec:
         accessModes:
         - "ReadWriteOnce"
         resources:
           requests:
-            storage: {{ .Values.storageSize }}
+            storage: {{ .Values.wal.storageSize }}
+      {{- end }}
   users:
     - name: postgres
       databases:

--- a/cas-obps-postgres/templates/PostgresCluster.yaml
+++ b/cas-obps-postgres/templates/PostgresCluster.yaml
@@ -56,6 +56,12 @@ spec:
                 matchLabels:
                   postgres-operator.crunchydata.com/cluster: {{ template "cas-obps-postgres.fullname" . }}
                   postgres-operator.crunchydata.com/instance-set: pgha1
+      walVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: {{ .Values.storageSize }}
   users:
     - name: postgres
       databases:

--- a/cas-obps-postgres/values-prod.yaml
+++ b/cas-obps-postgres/values-prod.yaml
@@ -10,3 +10,8 @@ resources:
     memory: 1200Mi
 
 storageSize: 3Gi
+
+wal:
+  separateStorage: true
+  storageSize: 3Gi
+

--- a/cas-obps-postgres/values-test.yaml
+++ b/cas-obps-postgres/values-test.yaml
@@ -9,3 +9,7 @@ resources:
   limits:
     cpu: 200m
     memory: 256Mi
+
+wal:
+  separateStorage: true
+

--- a/cas-obps-postgres/values.yaml
+++ b/cas-obps-postgres/values.yaml
@@ -70,6 +70,10 @@ resources: {}
 
 storageSize: 2Gi
 
+wal:
+  separateStorage: false
+  storageSize: 1Gi
+
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
Addresses bcgov/cas-registration#2540. This configures the Postgres Operator to create a separate PVC for the write-ahead-log for Postgres, which should reduce issues with Patroni and improve database stability. This is _not enabled_ in the `-dev` namespace, but _enabled_ in `-test` and `-prod`.

## Changes 🚧

- update cluster template to configure separate WAL volume
- add values config for WAL enablement and volume size
- bump chart version
